### PR TITLE
Specify repo information for safe_pqc_kyber dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,9 @@ optional = true
 #   https://github.com/Argyle-Software/kyber/issues/73
 #   https://github.com/Argyle-Software/kyber/issues/75
 #   https://github.com/Argyle-Software/kyber/issues/77
+version = "0.6"
+git = "https://github.com/bwesterb/argyle-kyber"
+rev = "d22c627406d436fa8446a0df48715b0ab78041c4"
 default-features = false
 features = ["kyber768", "std"] # TODO get rid of std dep
 optional = true


### PR DESCRIPTION
This crate doesn't compile on the latest `stable` toolchain.
```
# cargo build
error: failed to parse manifest at `/home/inahga/Projects/rust-hpke/Cargo.toml`

Caused by:
  dependency (safe_pqc_kyber) specified without providing a local path, Git repository, version, or workspace dependency to use
```

This is because at some point, this behavior was changed into an error, see this deprecation warning on `1.65`
```
# cargo +1.65 build
warning: dependency (safe_pqc_kyber) specified without providing a local path, Git repository, or version to use. This will be considered an error in future versions
    Updating crates.io index
...
```

I assume your intent was to point to your fork of `kyber`, so I've done so.